### PR TITLE
Implement the "setup" command for Docker installation via SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,72 @@
+[![tests](https://github.com/drzled/drzl/actions/workflows/tests.yml/badge.svg)](https://github.com/drzled/drzl/actions/workflows/tests.yml)
+
+# DRZL
+DRZL is a Laravel package that simplifies the deployment process for web applications. It allows you to deploy your application anywhere, from bare metal servers to cloud VMs, using Docker with zero downtime. By leveraging the dynamic reverse-proxy Traefik, DRZL can hold requests while the new application container is started and the old one is stopped. It works seamlessly across multiple hosts, using Symfony Process component to execute commands. With DRZL, you can deploy your Laravel applications with ease, without worrying about the underlying infrastructure.
+
+This will:
+- Connect to the servers over SSH (using root by default, authenticated by your ssh key)
+- Install Docker on any server that might be missing it (using apt-get): root access is needed via ssh for this.
+- Log into the registry both locally and remotely
+- Build the image using the standard Dockerfile in the root of the application.
+- Push the image to the registry.
+- Pull the image from the registry onto the servers.
+- Ensure Traefik is running and accepting traffic on port 80.
+- Ensure your app responds with 200 OK to GET /up (you must have curl installed inside your app image!).
+- Start a new container with the version of the app that matches the current git version hash.
+- Stop the old container running the previous version of the app.
+- Prune unused images and stopped containers to ensure servers don't fill up.
+
+Voila! All the servers are now serving the app on port 80. If you're just running a single server, you're ready to go. If you're running multiple servers, you need to put a load balancer in front of them.
+
+## Installation
+
+Installing DRZL is a simple process that can be completed in just a few steps. Before you begin, make sure you have `PHP 8.1+` or higher installed on your system.
+
+**The first step** is to require DRZL as a `dev` dependency in your project by running the following command on your command line.
+
+```bash
+composer require drzled/drzl --dev --with-all-dependencies
+```
+
+**Secondly**, you'll need to publish DRZL config file in your current Laravel project. This step will create a configuration file named `.drzl/drzl.yml` at the root folder of your Laravel project, which will enable you to fine-tune your infraestucture later.
+
+```bash
+drzl init
+```
+
+Then, edit the new file `.drzl/drzl.php`. It could look as simple as this:
+```yaml
+name: Drzl
+servers:
+    - 129.168.0.1
+    - 129.168.0.2
+```
+**Finally** you need add some environment variables on your `.env` file. 
+```bash
+DRZL_DOCKER_REGISTER_SERVER="ghcr.io"
+LARKS_DOCKER_REGISTRY_USER="drzl"
+LARKS_DOCKER_REGISTRY_PASSWORD="[your-personal-access-token]"
+```
+Please, ensure to set the right value for each variable. 
+
+# Run CLI Using Docker
+
+```bash
+eval `ssh-agent -s` && echo ${SSH_PRIVATE_KEY} | ssh-add - > /dev/null
+```
+
+```bash
+alias drzl="docker run --rm -it --user $UID:1000 -v /var/run/docker.sock:/var/run/docker.sock -v ${PWD}:/app -v "${SSH_AUTH_SOCK}:${SSH_AUTH_SOCK}" -e SSH_AUTH_SOCK=${SSH_AUTH_SOCK} drzl"
+```
+
+Now you're ready to deploy to the servers:
+```bash
+drzl deploy
+```
+
+## Dev on Codespace
+
+SSH Agent
+```
+eval `ssh-agent -s` && echo ${SSH_PRIVATE_KEY} | ssh-add - > /dev/null
+```

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -33,7 +33,7 @@ $app->singleton(
 
 $app->singleton(
     Illuminate\Contracts\Debug\ExceptionHandler::class,
-    Illuminate\Foundation\Exceptions\Handler::class
+    \Drzl\Exceptions\Handler::class
 );
 
 /*

--- a/config/drzl.php
+++ b/config/drzl.php
@@ -1,5 +1,5 @@
 <?php
 
 return [
-    
+    'lockfile' => "/tmp/.drzl.lockfile"
 ];

--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Drzl\Commands;
+
+use Drzl\Manifest;
+use LaravelZero\Framework\Commands\Command;
+
+abstract class BaseCommand extends Command
+{
+    public function __construct(protected readonly Manifest $manifest)
+    {
+        parent::__construct();
+    }
+}

--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -3,6 +3,7 @@
 namespace Drzl\Commands;
 
 use Drzl\Manifest;
+use Drzl\Processes\ProcessInterface;
 use LaravelZero\Framework\Commands\Command;
 
 abstract class BaseCommand extends Command
@@ -10,5 +11,11 @@ abstract class BaseCommand extends Command
     public function __construct(protected readonly Manifest $manifest)
     {
         parent::__construct();
+    }
+
+    protected function withOutput(ProcessInterface $process, \Closure $callback) {
+        $process->withOutput($this->getOutput());
+
+        $callback($process);
     }
 }

--- a/src/Commands/Concerns/LockableServer.php
+++ b/src/Commands/Concerns/LockableServer.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drzl\Commands\Concerns;
+
+trait LockableServer
+{
+    protected function acquireLock(\Closure $callback): void
+    {
+        $this->call('lock:acquire', [
+            'reason' => 'Automatic deploy lock.',
+        ]);
+
+        try {
+            $callback();
+        } catch (\Throwable $exception) {
+            $this->error($exception->getMessage());
+        }
+
+        $this->call('lock:release');
+    }
+}

--- a/src/Commands/Concerns/LockableServer.php
+++ b/src/Commands/Concerns/LockableServer.php
@@ -12,11 +12,7 @@ trait LockableServer
             'reason' => 'Automatic deploy lock.',
         ]);
 
-        try {
-            $callback();
-        } catch (\Throwable $exception) {
-            $this->error($exception->getMessage());
-        }
+        $callback();
 
         $this->call('lock:release');
     }

--- a/src/Commands/InitCommand.php
+++ b/src/Commands/InitCommand.php
@@ -4,19 +4,11 @@ declare(strict_types=1);
 
 namespace Drzl\Commands;
 
-use Drzl\Manifest;
-use Illuminate\Console\Command;
-
-final class InitCommand extends Command
+final class InitCommand extends BaseCommand
 {
     protected $signature = 'init';
 
     protected $description = 'Initializes the manifiest file with default values';
-
-    public function __construct(protected Manifest $manifest)
-    {
-        parent::__construct();
-    }
 
     public function handle(): int
     {

--- a/src/Commands/LockAcquireCommand.php
+++ b/src/Commands/LockAcquireCommand.php
@@ -11,7 +11,7 @@ class LockAcquireCommand extends BaseCommand
     protected $signature = 'lock:acquire
                             {reason : Helps identify the purpose of the lock}';
 
-    protected $description = 'Command description';
+    protected $description = 'Obtain an exclusive lock on the remote server';
 
     public function handle()
     {

--- a/src/Commands/LockAcquireCommand.php
+++ b/src/Commands/LockAcquireCommand.php
@@ -4,16 +4,38 @@ declare(strict_types=1);
 
 namespace Drzl\Commands;
 
+use Drzl\Manifest;
+use Drzl\Processes\ServerLock;
 use LaravelZero\Framework\Commands\Command;
 
 class LockAcquireCommand extends Command
 {
-    protected $signature = 'lock:acquire';
+    protected $signature = 'lock:acquire
+                            {reason : Helps identify the purpose of the lock}';
 
     protected $description = 'Command description';
 
+    public function __construct(protected readonly Manifest $manifest)
+    {
+        parent::__construct();
+    }
+
     public function handle()
     {
-        //
+        $this->line('Acquiring the servers lock...');
+
+        $processResult = with($this->manifest->primaryServer(), function ($primaryServer) {
+            return ServerLock::on($primaryServer)->getExclusiveLock(
+                config('drzl.lockfile'),
+                $this->argument('reason')
+            );
+        });
+
+        if ($processResult->failed()) {
+            $this->error('Error: Unable to acquire server lock.');
+            return self::FAILURE;
+        }
+
+        $this->info('Server lock has been acquired');
     }
 }

--- a/src/Commands/LockAcquireCommand.php
+++ b/src/Commands/LockAcquireCommand.php
@@ -4,21 +4,14 @@ declare(strict_types=1);
 
 namespace Drzl\Commands;
 
-use Drzl\Manifest;
 use Drzl\Processes\ServerLock;
-use LaravelZero\Framework\Commands\Command;
 
-class LockAcquireCommand extends Command
+class LockAcquireCommand extends BaseCommand
 {
     protected $signature = 'lock:acquire
                             {reason : Helps identify the purpose of the lock}';
 
     protected $description = 'Command description';
-
-    public function __construct(protected readonly Manifest $manifest)
-    {
-        parent::__construct();
-    }
 
     public function handle()
     {

--- a/src/Commands/LockAcquireCommand.php
+++ b/src/Commands/LockAcquireCommand.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drzl\Commands;
+
+use LaravelZero\Framework\Commands\Command;
+
+class LockAcquireCommand extends Command
+{
+    protected $signature = 'lock:acquire';
+
+    protected $description = 'Command description';
+
+    public function handle()
+    {
+        //
+    }
+}

--- a/src/Commands/LockReleaseCommand.php
+++ b/src/Commands/LockReleaseCommand.php
@@ -4,16 +4,33 @@ declare(strict_types=1);
 
 namespace Drzl\Commands;
 
+use Drzl\Manifest;
+use Drzl\Processes\ServerLock;
 use LaravelZero\Framework\Commands\Command;
 
 class LockReleaseCommand extends Command
 {
     protected $signature = 'lock:release';
 
-    protected $description = 'Command description';
+    protected $description = 'Release an exclusive lock on the remote server';
 
-    public function handle()
+    public function __construct(public readonly Manifest $manifest)
     {
-        //
+        parent::__construct();
+    }
+
+    public function handle(): void
+    {
+        $this->line('Releasing the servers lock...');
+
+        $processResult = with($this->manifest->primaryServer(), function ($primaryServer) {
+            return ServerLock::on($primaryServer)->releaseLock(
+                config('drzl.lockfile')
+            );
+        });
+        
+        if ($processResult->successful()) {
+            $this->info('Server lock has been released');
+        }
     }
 }

--- a/src/Commands/LockReleaseCommand.php
+++ b/src/Commands/LockReleaseCommand.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drzl\Commands;
+
+use LaravelZero\Framework\Commands\Command;
+
+class LockReleaseCommand extends Command
+{
+    protected $signature = 'lock:release';
+
+    protected $description = 'Command description';
+
+    public function handle()
+    {
+        //
+    }
+}

--- a/src/Commands/LockReleaseCommand.php
+++ b/src/Commands/LockReleaseCommand.php
@@ -4,20 +4,13 @@ declare(strict_types=1);
 
 namespace Drzl\Commands;
 
-use Drzl\Manifest;
 use Drzl\Processes\ServerLock;
-use LaravelZero\Framework\Commands\Command;
 
-class LockReleaseCommand extends Command
+class LockReleaseCommand extends BaseCommand
 {
     protected $signature = 'lock:release';
 
     protected $description = 'Release an exclusive lock on the remote server';
-
-    public function __construct(public readonly Manifest $manifest)
-    {
-        parent::__construct();
-    }
 
     public function handle(): void
     {

--- a/src/Commands/ServerBootstrap.php
+++ b/src/Commands/ServerBootstrap.php
@@ -13,7 +13,7 @@ class ServerBootstrap extends BaseCommand
     public function handle()
     {
         $this->manifest->servers()->each(function (string $server) {
-             if (Docker::on($server)->isInstalled()->successful()) {
+            if (Docker::on($server)->isInstalled()->successful()) {
                 $this->info("Docker is already installed on {$server}");
                 
                 return;

--- a/src/Commands/ServerBootstrap.php
+++ b/src/Commands/ServerBootstrap.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drzl\Commands;
+
+use Drzl\Processes\Docker;
+
+class ServerBootstrap extends BaseCommand
+{
+    protected $signature = 'server:bootstrap';
+
+    protected $description = 'Set up Docker to run Drzl apps';
+
+    public function handle()
+    {
+        $this->manifest->servers()->each(function (string $server) {
+             if (Docker::on($server)->isInstalled()->successful()) {
+                $this->info("Docker is already installed on {$server}");
+                
+                return;
+            }
+
+            if (Docker::on($server)->hasSuperuserPermissions()->failed()) {
+                $this->error("Docker is not installed on {$server} and can\'t be automatically installed without having root access. Install Docker manually: https://docs.docker.com/engine/install/");
+                
+                exit(self::FAILURE);
+            }
+
+            $this->comment("Missing Docker on {$server}. Installing...");
+            
+            $this->withOutput(Docker::on($server), function ($docker) {
+                $docker->install();
+            });
+
+            $this->info("Docker has been installed on {$server}.");
+        });
+    }
+}

--- a/src/Commands/SetupCommand.php
+++ b/src/Commands/SetupCommand.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drzl\Commands;
+
+use LaravelZero\Framework\Commands\Command;
+
+class SetupCommand extends Command
+{
+    protected $signature = 'setup';
+
+    protected $description = 'Configuration the app servers';
+
+    public function handle()
+    {
+        //
+    }
+}

--- a/src/Commands/SetupCommand.php
+++ b/src/Commands/SetupCommand.php
@@ -4,16 +4,20 @@ declare(strict_types=1);
 
 namespace Drzl\Commands;
 
-use LaravelZero\Framework\Commands\Command;
+use Drzl\Commands\Concerns\LockableServer;
 
-class SetupCommand extends Command
+class SetupCommand extends BaseCommand
 {
+    use LockableServer;
+    
     protected $signature = 'setup';
 
     protected $description = 'Configuration the app servers';
 
     public function handle()
     {
-        //
+        $this->acquireLock(function () {
+            $this->call('server:bootstrap');
+        });
     }
 }

--- a/src/DrzlServiceProvider.php
+++ b/src/DrzlServiceProvider.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Drzl;
 
+use Illuminate\Console\Events\CommandStarting;
 use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 
 class DrzlServiceProvider extends ServiceProvider
@@ -21,5 +23,8 @@ class DrzlServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
+        Event::listen(function (CommandStarting $event) {
+            app()->bind('output', fn () => $event->output);
+        });
     }
 }

--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Drzl\Exceptions;
+
+use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Illuminate\Process\Exceptions\ProcessTimedOutException;
+use Throwable;
+
+class Handler extends ExceptionHandler
+{
+    /**
+     * A list of the exception types that are not reported.
+     *
+     * @var array
+     */
+    protected $dontReport = [
+        // \Illuminate\Database\Eloquent\ModelNotFoundException::class,
+    ];
+
+    /**
+     * Register the exception handling callbacks for the application.
+     *
+     * @return void
+     */
+    public function register()
+    {
+       //
+    }
+
+    /**
+     * Report or log an exception.
+     *
+     * @param  \Throwable  $e
+     * @return void
+     *
+     * @throws \Throwable
+     */
+    public function report (\Throwable $exception)
+    {
+        if ($exception instanceof ProcessTimedOutException) {
+            with($exception->getMessage(), function ($message) {
+                app('output')->writeln("<error>{$message}</error>");
+                exit(1);
+            });
+        }
+    }
+}

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -23,9 +23,15 @@ final class Manifest {
         ) ?? [];
     }
 
+    function servers(): Collection {
+        return collect(
+            data_get($this->values, 'servers', [])
+        );
+    }
+
     public function primaryServer(): string
     {
-        return data_get($this->values, 'servers.0', 'localhost');
+        return $this->servers()->first(default: 'localhost');
     }
 
     public function update(array $values): bool

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -23,6 +23,11 @@ final class Manifest {
         ) ?? [];
     }
 
+    public function primaryServer(): string
+    {
+        return data_get($this->values, 'servers.0', 'localhost');
+    }
+
     public function update(array $values): bool
     {
         $this->values = $values;

--- a/src/ProcessRunner.php
+++ b/src/ProcessRunner.php
@@ -23,13 +23,15 @@ final class ProcessRunner
     }
 
 
-    public function __invoke($process): ProcessResult
+    public function __invoke($process, bool $stream = false): ProcessResult
     {
         $server = $process->server;
 
-        return Process::run($process->script(), function($type, $message) use ($server) {
-            $this->output->writeln('');
-            $this->output->writeln("<comment>INFO [{$server}] {$message}</comment>");
+        return Process::run($process->script(), function($type, $message) use ($server, $stream) {
+            if ($stream) {
+                $this->output->writeln('');
+                $this->output->writeln("<comment>INFO [{$server}] {$message}</comment>");
+            }
         });        
     }
 }

--- a/src/ProcessRunner.php
+++ b/src/ProcessRunner.php
@@ -4,34 +4,28 @@ declare(strict_types=1);
 
 namespace Drzl;
 
+use Illuminate\Console\OutputStyle;
 use Illuminate\Contracts\Process\ProcessResult;
 use Illuminate\Support\Facades\Process;
-use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Stopwatch\Stopwatch;
 
 final class ProcessRunner
 {
-    protected ConsoleOutput $output;
-
     protected Stopwatch $stopwatch;
 
     public function __construct()
     {
-        $this->output = app('output');
-
         $this->stopwatch = new Stopwatch();
     }
 
 
-    public function __invoke($process, bool $stream = false): ProcessResult
+    public function __invoke($process, ?OutputStyle $output = null): ProcessResult
     {
         $server = $process->server;
 
-        return Process::run($process->script(), function($type, $message) use ($server, $stream) {
-            if ($stream) {
-                $this->output->writeln('');
-                $this->output->writeln("<comment>INFO [{$server}] {$message}</comment>");
-            }
+        return Process::run($process->script(), function($type, $message) use ($server, $output) {
+                $output?->writeln('');
+                $output?->writeln("<comment>INFO [{$server}] {$message}</comment>");
         });        
     }
 }

--- a/src/ProcessRunner.php
+++ b/src/ProcessRunner.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drzl;
+
+use Illuminate\Contracts\Process\ProcessResult;
+use Illuminate\Support\Facades\Process;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Stopwatch\Stopwatch;
+
+final class ProcessRunner
+{
+    protected ConsoleOutput $output;
+
+    protected Stopwatch $stopwatch;
+
+    public function __construct()
+    {
+        $this->output = app('output');
+
+        $this->stopwatch = new Stopwatch();
+    }
+
+
+    public function __invoke($process): ProcessResult
+    {
+        $server = $process->server;
+
+        return Process::run($process->script(), function($type, $message) use ($server) {
+            $this->output->writeln('');
+            $this->output->writeln("<comment>INFO [{$server}] {$message}</comment>");
+        });        
+    }
+}

--- a/src/Processes/Concerns/RunnableOverSSH.php
+++ b/src/Processes/Concerns/RunnableOverSSH.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drzl\Processes\Concerns;
+
+trait RunnableOverSSH
+{
+    protected function prepareScriptOverSSH(): string
+    {
+        return sprintf(
+            "ssh %s -T -p%s %s@%s '%s'",
+            '-o LogLevel=ERROR -o "StrictHostKeyChecking=no" -o "UserKnownHostsFile=/dev/null"',
+            config('larsk.ssh_port', '22'),
+            config('larsk.ssh_user', 'root'),
+            $this->server,
+            $this->script
+        );
+    }
+}

--- a/src/Processes/Docker.php
+++ b/src/Processes/Docker.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drzl\Processes;
+
+use Illuminate\Contracts\Process\ProcessResult;
+
+final class Docker extends ProcessBase
+{
+    public function install(): ProcessResult
+    {
+        return $this->pipe(['curl -fsSL https://get.docker.com', 'sh'])->run();
+    }
+
+    public function isInstalled(): ProcessResult
+    {
+        return $this->docker(argument: '-v');
+    }
+
+    public function hasSuperuserPermissions(): ProcessResult
+    {
+        return $this->command('[ "${EUID:-$(id -u)}" -eq 0 ]')->run();
+    }
+}

--- a/src/Processes/ProcessBase.php
+++ b/src/Processes/ProcessBase.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Drzl\Processes;
 
-use Drzl\Processes\Concerns\RunnableOverSSH;
 use Drzl\ProcessRunner;
+use Drzl\Processes\Concerns\RunnableOverSSH;
 use Illuminate\Console\OutputStyle;
 use Illuminate\Contracts\Process\ProcessResult;
 use Illuminate\Support\Arr;
 
-abstract class ProcessBase
+abstract class ProcessBase implements ProcessInterface
 {
     use RunnableOverSSH;
 

--- a/src/Processes/ProcessBase.php
+++ b/src/Processes/ProcessBase.php
@@ -14,6 +14,8 @@ abstract class ProcessBase
     use RunnableOverSSH;
 
     public readonly string $script;
+    
+    protected bool $requiredStream = false;
 
     protected ProcessRunner $runner;
 
@@ -50,6 +52,23 @@ abstract class ProcessBase
 
     public function run(): ProcessResult
     {
-        return $this->runner->__invoke($this);
+        return $this->runner->__invoke(
+            process:$this,
+            stream: $this->requiredStream
+        );
+    }
+
+    public function withOutput(): static
+    {
+        $this->requiredStream = true;
+
+        return $this;
+    }
+
+    public function docker(string $argument): ProcessResult
+    {
+        $this->script = "docker {$argument}";
+
+        return $this->run();
     }
 }

--- a/src/Processes/ProcessBase.php
+++ b/src/Processes/ProcessBase.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drzl\Processes;
+
+use Drzl\Processes\Concerns\RunnableOverSSH;
+use Drzl\ProcessRunner;
+use Illuminate\Contracts\Process\ProcessResult;
+use Illuminate\Support\Arr;
+
+abstract class ProcessBase
+{
+    use RunnableOverSSH;
+
+    public readonly string $script;
+
+    protected ProcessRunner $runner;
+
+    final public function __construct(public readonly string $server)
+    {        
+        $this->runner = new ProcessRunner();
+    }
+
+    public static function on(string $server): static
+    {
+        return new static($server);
+    }
+
+    public function command(string $script): static
+    {
+        $this->script = $script;
+
+        return $this;
+    }
+
+    public function pipe(array $commandsToPipe): static
+    {
+        return $this->command(Arr::join($commandsToPipe, ' | '));
+    }
+
+    public function script(): string
+    {
+        if (in_array($this->server, ['localhost', '127.0.0.1'])) {
+            return $this->script;
+        }
+
+        return $this->prepareScriptOverSSH();
+    }
+
+    public function run(): ProcessResult
+    {
+        return $this->runner->__invoke($this);
+    }
+}

--- a/src/Processes/ProcessBase.php
+++ b/src/Processes/ProcessBase.php
@@ -6,6 +6,7 @@ namespace Drzl\Processes;
 
 use Drzl\Processes\Concerns\RunnableOverSSH;
 use Drzl\ProcessRunner;
+use Illuminate\Console\OutputStyle;
 use Illuminate\Contracts\Process\ProcessResult;
 use Illuminate\Support\Arr;
 
@@ -15,7 +16,7 @@ abstract class ProcessBase
 
     public readonly string $script;
     
-    protected bool $requiredStream = false;
+    protected ?OutputStyle $output = null;
 
     protected ProcessRunner $runner;
 
@@ -54,13 +55,13 @@ abstract class ProcessBase
     {
         return $this->runner->__invoke(
             process:$this,
-            stream: $this->requiredStream
+            output: $this->output
         );
     }
 
-    public function withOutput(): static
+    public function withOutput(OutputStyle $output): static
     {
-        $this->requiredStream = true;
+        $this->output = $output;
 
         return $this;
     }

--- a/src/Processes/ProcessInterface.php
+++ b/src/Processes/ProcessInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drzl\Processes;
+
+use Illuminate\Console\OutputStyle;
+
+interface ProcessInterface
+{
+    public function withOutput(OutputStyle $output): static;
+}

--- a/src/Processes/ServerLock.php
+++ b/src/Processes/ServerLock.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drzl\Processes;
+
+use Illuminate\Contracts\Process\ProcessResult;
+
+final class ServerLock extends ProcessBase
+{
+    public function getExclusiveLock(string $lockfile, string $reason): ProcessResult
+    {
+        return $this->command("if [ -e \"{$lockfile}\" ]; then cat {$lockfile} | base64 --decode 1>&2; exit 1; else echo '{$reason}' | base64 > {$lockfile}; fi")
+                    ->run();
+    }
+
+    public function releaseLock(string $lockfile): ProcessResult
+    {
+        return $this->command("rm {$lockfile}")
+                    ->run();
+    }
+}


### PR DESCRIPTION
This pull request addresses issue #5 by implementing the "setup" command, which acquires a server lock to prevent concurrent operations and facilitates the installation of Docker via SSH.

## Changes Made
- [x] Developed a server lock mechanism to acquire and release locks for exclusive server access.
- [ ] Implemented error handling to handle scenarios where the server lock cannot be acquired, providing informative error messages for troubleshooting.
- [ ] Enhanced the "setup" command to detect the presence of Docker on the server.
- [ ] Added functionality to install Docker using the appropriate package manager via SSH if it is not already installed.
- [ ] Improved feedback and error messaging during the installation process to assist users in resolving any encountered issues.
- [ ] Ensured proper release of the server lock upon completion or in case of any errors during the installation process33.

## Testing done
- [ ] Tested the "setup" command on various servers with different configurations to ensure successful server lock acquisition and Docker installation.
- [ ] Validated the behavior of error handling and error messaging during the installation process.